### PR TITLE
Add /api Prefix to REST Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ Response:
 {
   "name": "ShopCarts Demo REST API Service",
   "version": "1.0",
-  "paths": "http://localhost:8080/shopcarts"
+  "paths": "http://localhost:8080/api/shopcarts"
 }
 ```
 ### <u>ShopCarts Endpoints and Expected Responses</u>
 ```http
-POST   /shopcarts
-GET    /shopcarts
-GET    /shopcarts/<shopcart_id>
-DELETE /shopcarts/<shopcart_id>
+POST   /api/shopcarts
+GET    /api/shopcarts
+GET    /api/shopcarts/<shopcart_id>
+DELETE /api/shopcarts/<shopcart_id>
 ```
 - **Create a Shopcart** (expects a json input) 
     ```http
-    POST /shopcarts
+    POST /api/shopcarts
     Content-Type: application/json
     ```
     Request Body:
@@ -93,7 +93,7 @@ DELETE /shopcarts/<shopcart_id>
     ```
 - **List Shopcarts**
      ```http
-    GET /shopcarts
+    GET /api/shopcarts
     ```
     Response 
     ```json
@@ -111,7 +111,7 @@ DELETE /shopcarts/<shopcart_id>
 - **Read a Shopcart**
     
     ```http
-    GET /shopcarts/<shopcart_id>
+    GET /api/shopcarts/<shopcart_id>
     ```
   Response (assuming input 855)
   ```json
@@ -122,11 +122,11 @@ DELETE /shopcarts/<shopcart_id>
   ```
 - **Delete a Shopcart** 
   ```http
-    DELETE /shopcarts/<shopcart_id>
-    ```
+    DELETE /api/shopcarts/<shopcart_id>
+  ```
 - **Update a Shopcart**
   ```http
-  PUT /shopcarts/<shopcart_id>
+  PUT /api/shopcarts/<shopcart_id>
   Content-Type: application/json
   ```
   Request Body:
@@ -149,15 +149,15 @@ DELETE /shopcarts/<shopcart_id>
 
 ### <u>Items Endpoints and Expected Responses</u>
 ```http
-POST   /shopcarts/<shopcart_id>/items
-GET    /shopcarts/<shopcart_id>/items
-GET    /shopcarts/<shopcart_id>/items/<item_id>
-PUT    /shopcarts/<shopcart_id>/items/<item_id>
+POST   /api/shopcarts/<shopcart_id>/items
+GET    /api/shopcarts/<shopcart_id>/items
+GET    /api/shopcarts/<shopcart_id>/items/<item_id>
+PUT    /api/shopcarts/<shopcart_id>/items/<item_id>
 ```
 
 - **Create an Item inside a Shopcart**
   ```http
-  POST /shopcarts/<shopcart_id>/items
+  POST /api/shopcarts/<shopcart_id>/items
   Content-Type: application/json
   ```
   Request Body:
@@ -181,7 +181,7 @@ PUT    /shopcarts/<shopcart_id>/items/<item_id>
 
 - **List All Items in a Shopcart**
   ```http
-  GET /shopcarts/<shopcart_id>/items
+  GET /api/shopcarts/<shopcart_id>/items
   ```
   Response:
   ```json
@@ -205,7 +205,7 @@ PUT    /shopcarts/<shopcart_id>/items/<item_id>
 
 - **Retrieve a Specific Item**
   ```http
-  GET /shopcarts/<shopcart_id>/items/<item_id>
+  GET /api/shopcarts/<shopcart_id>/items/<item_id>
   ```
   Response:
   ```json
@@ -219,12 +219,12 @@ PUT    /shopcarts/<shopcart_id>/items/<item_id>
   ```
 - **Delete an Item in a Shopcart**
     ```http
-  DELETE /shopcarts/<shopcart_id>/items/<item_id>
+  DELETE /api/shopcarts/<shopcart_id>/items/<item_id>
   ```
 
 - **Update an Item in a Shopcart**
   ```http
-  PUT /shopcarts/<shopcart_id>/items/<item_id>
+  PUT /api/shopcarts/<shopcart_id>/items/<item_id>
   Content-Type: application/json
   ```
   Request Body:

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -9,7 +9,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /shopcarts
+          - path: /api/shopcarts
             pathType: Prefix
             backend:
               service:

--- a/service/routes.py
+++ b/service/routes.py
@@ -42,8 +42,8 @@ def index():
             name="ShopCarts Demo REST API Service",
             version="1.0",
             # The host application owns misc routes like `/`, `/admin`, `/health`,
-            # while the Flask-RESTX Api manages the REST resources under `/shopcarts`.
-            paths="/shopcarts",
+            # while the Flask-RESTX Api manages the REST resources under `/api/shopcarts`.
+            paths="/api/shopcarts",
         ),
         status.HTTP_200_OK,
     )
@@ -74,8 +74,9 @@ def health():
 #   - The plain Flask routes above (`/`, `/admin`, `/health`) belong to
 #     the host application and are not part of the REST API surface.
 #   - The Flask-RESTX `Api` and namespaces below define the REST
-#     resources (e.g., `/shopcarts`) and should not register misc/host
-#     routes to avoid collisions with the root URL.
+#     resources (e.g., `/api/shopcarts`) under the `/api` prefix and
+#     should not register misc/host routes to avoid collisions with the
+#     root URL.
 ######################################################################
 api = Api(
     app,
@@ -83,6 +84,7 @@ api = Api(
     title="ShopCarts REST API Service",
     description="ShopCarts service with Swagger (Flask-RESTX)",
     doc="/apidocs",
+    prefix="/api",
 )
 
 # Namespaces
@@ -415,7 +417,7 @@ class ShopcartClear(Resource):
     """Clear all items from a ShopCart (idempotent)"""
 
     def post(self, shopcart_id: int):
-        """POST /shopcarts/<id>/clear — remove all items from a cart (idempotent)."""
+        """POST /api/shopcarts/<id>/clear — remove all items from a cart (idempotent)."""
         app.logger.info("Request to clear shopcart id=%s", shopcart_id)
 
         cart = ShopCarts.find(shopcart_id)

--- a/service/static/js/shopcarts_admin.js
+++ b/service/static/js/shopcarts_admin.js
@@ -1,4 +1,6 @@
 $(function () {
+  const API_BASE = "/api/shopcarts";
+
   function flash(message) {
     $("#flash_message").empty().text(message || "");
   }
@@ -34,7 +36,7 @@ $(function () {
 
     $.ajax({
       type: "POST",
-      url: "/shopcarts",
+      url: API_BASE,
       contentType: "application/json",
       data: JSON.stringify({ customer_id: customer_id })
     })
@@ -51,7 +53,7 @@ $(function () {
     const id = $("#shopcart_id").val();
     $("#flash_message").empty();
 
-    $.ajax({ type: "GET", url: `/shopcarts/${id}` })
+    $.ajax({ type: "GET", url: `${API_BASE}/${id}` })
       .done(function (res) {
         update_cart_form(res);
         flash("Success");
@@ -69,7 +71,7 @@ $(function () {
 
     $.ajax({
       type: "PUT",
-      url: `/shopcarts/${id}`,
+      url: `${API_BASE}/${id}`,
       contentType: "application/json",
       data: JSON.stringify({ customer_id: customer_id })
     })
@@ -87,7 +89,7 @@ $(function () {
     $("#flash_message").empty();
 
     if (!id) return;
-    $.ajax({ type: "DELETE", url: `/shopcarts/${id}` })
+    $.ajax({ type: "DELETE", url: `${API_BASE}/${id}` })
       .done(function () {
         clear_cart_form();
         flash("Shopcart deleted");
@@ -103,7 +105,7 @@ $(function () {
     if (customer_id) qs = `customer_id=${customer_id}`;
     $("#flash_message").empty();
 
-    $.ajax({ type: "GET", url: `/shopcarts?${qs}` })
+    $.ajax({ type: "GET", url: `${API_BASE}?${qs}` })
       .done(function (res) {
         $("#shopcarts_results").empty();
         let table = '<table class="table table-striped" cellpadding="10">';
@@ -128,7 +130,7 @@ $(function () {
     const id = $("#shopcart_id").val();
     $("#flash_message").empty();
     if (!id) return;
-    $.ajax({ type: "POST", url: `/shopcarts/${id}/clear` })
+    $.ajax({ type: "POST", url: `${API_BASE}/${id}/clear` })
       .done(function (res) {
         update_cart_form(res);
         flash("Cart cleared");
@@ -152,7 +154,7 @@ $(function () {
     $("#flash_message").empty();
     $.ajax({
       type: "POST",
-      url: `/shopcarts/${sid}/items`,
+      url: `${API_BASE}/${sid}/items`,
       contentType: "application/json",
       data: JSON.stringify({ product_id, quantity, price })
     })
@@ -169,7 +171,7 @@ $(function () {
     const sid = getItemCartId();
     const item_id = $("#item_id").val();
     $("#flash_message").empty();
-    $.ajax({ type: "GET", url: `/shopcarts/${sid}/items/${item_id}` })
+    $.ajax({ type: "GET", url: `${API_BASE}/${sid}/items/${item_id}` })
       .done(function (res) {
         update_item_form(res);
         flash("Success");
@@ -188,7 +190,7 @@ $(function () {
     $("#flash_message").empty();
     $.ajax({
       type: "PUT",
-      url: `/shopcarts/${sid}/items/${item_id}`,
+      url: `${API_BASE}/${sid}/items/${item_id}`,
       contentType: "application/json",
       data: JSON.stringify({ quantity, unit_price })
     })
@@ -206,7 +208,7 @@ $(function () {
     const item_id = $("#item_id").val();
     $("#flash_message").empty();
     if (!sid || !item_id) return;
-    $.ajax({ type: "DELETE", url: `/shopcarts/${sid}/items/${item_id}` })
+    $.ajax({ type: "DELETE", url: `${API_BASE}/${sid}/items/${item_id}` })
       .done(function () {
         clear_item_form();
         flash("Item deleted");
@@ -219,7 +221,7 @@ $(function () {
   $("#list-items-btn").click(function () {
     const sid = getItemCartId();
     $("#flash_message").empty();
-    $.ajax({ type: "GET", url: `/shopcarts/${sid}/items` })
+    $.ajax({ type: "GET", url: `${API_BASE}/${sid}/items` })
       .done(function (res) {
         $("#items_results").empty();
         let table = '<table class="table table-striped" cellpadding="10">';

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -32,7 +32,7 @@ from .factories import ShopCartFactory, ItemFactory
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
 )
-BASE_URL = "/shopcarts"
+BASE_URL = "/api/shopcarts"
 
 
 ######################################################################


### PR DESCRIPTION
- Modify routes.py to move all shopcart API under /api prefix.  
- update k8s/ingress.yaml, README.md, and shopcarts_admin.js to reflect new api path
